### PR TITLE
Taille par défaut pour nosgestesclimat qui n'a plus iframeresizer

### DIFF
--- a/src/components/page/Embed.js
+++ b/src/components/page/Embed.js
@@ -8,6 +8,7 @@ const Wrapper = styled(IframeResizer)`
   max-width: 49rem;
   margin: 0 auto 5.5rem;
   border: none;
+  height: 100vh;
 `
 export default function Embed(props) {
   return (


### PR DESCRIPTION
@florianpanchout pour réparer l'iframe NGC. 

Pas forcément la meilleure solution, mais ça semble marcher. Pour les iframes comme impactCO2, iframeresizer va écraser cette hauteur fixée par défaut. 

T'en penses quoi ?